### PR TITLE
Admins can now reset passwords of regular users

### DIFF
--- a/Controllers/Website/Administration/Accounts.php
+++ b/Controllers/Website/Administration/Accounts.php
@@ -3,6 +3,7 @@
 namespace VoicesOfWynn\Controllers\Website\Administration;
 
 use VoicesOfWynn\Controllers\Website\WebpageController;
+use VoicesOfWynn\Models\Website\UserException;
 use VoicesOfWynn\Models\Website\AccountManager;
 use VoicesOfWynn\Models\Website\User;
 
@@ -20,8 +21,19 @@ class Accounts extends WebpageController
                 case 'reset-password':
                     $user = new User();
                     $user->setData(array('id' => $args[0]));
-                    $newPassword = $user->resetPassword();
-                    exit($newPassword); //TODO Not ideal
+                    try {
+                        $newPassword = $user->resetPassword();
+                    } catch (UserException $e) {
+                        exit($e->getMessage());
+                    }
+                    exit('The new password for this user account is:
+                    
+' . $newPassword . '
+
+Be sure to send it to the voice actor.
+
+Tip: Just screenshot the password and send it as an image, if you don\'t want to rewrite it.
+I know that it would be great if it was copied automatically, but I\'m having some issues with implementing that.'); //TODO Not ideal
 			    case 'clear-bio':
 			    	$user = new User();
 			    	$user->setData(array('id' => $args[0]));

--- a/Controllers/Website/Administration/Accounts.php
+++ b/Controllers/Website/Administration/Accounts.php
@@ -17,6 +17,11 @@ class Accounts extends WebpageController
     	if (count($args) > 0)
     	{
     		switch (array_shift($args)) {
+                case 'reset-password':
+                    $user = new User();
+                    $user->setData(array('id' => $args[0]));
+                    $newPassword = $user->resetPassword();
+                    exit($newPassword); //TODO Not ideal
 			    case 'clear-bio':
 			    	$user = new User();
 			    	$user->setData(array('id' => $args[0]));
@@ -46,18 +51,19 @@ class Accounts extends WebpageController
 				    return 400;
 		    }
 	    }
+        else {
+            self::$data['base_description'] = 'Tool for the administrators to manage accounts of the contributors.';
 
-        self::$data['base_description'] = 'Tool for the administrators to manage accounts of the contributors.';
-    
-        $accountManager = new AccountManager();
-        self::$data['accounts_roles'] = $accountManager->getRoles();
-        self::$data['accounts_accounts'] = $accountManager->getUsers();
-    
-        self::$cssFiles[] = 'accounts';
-        self::$jsFiles[] = 'accounts';
-        self::$views[] = 'accounts';
-        
-        return true;
+            $accountManager = new AccountManager();
+            self::$data['accounts_roles'] = $accountManager->getRoles();
+            self::$data['accounts_accounts'] = $accountManager->getUsers();
+
+            self::$cssFiles[] = 'accounts';
+            self::$jsFiles[] = 'accounts';
+            self::$views[] = 'accounts';
+
+            return true;
+        }
     }
 }
 

--- a/Controllers/Website/Comments.php
+++ b/Controllers/Website/Comments.php
@@ -67,7 +67,7 @@ class Comments extends WebpageController
 	}
 	
 	/**
-	 * Processing method for DELETE requests to this controller (a comment is being deleted by a system admin)
+	 * Processing method for DELETE requests to this controller (a comment is being deleted by a system admin or the author)
 	 * Verification is done before affecting database
 	 * @param array $args
 	 * @return bool

--- a/Controllers/Website/Rating.php
+++ b/Controllers/Website/Rating.php
@@ -39,7 +39,7 @@ class Rating extends WebpageController
                     else {
 	                    $commentId = $recording->comment(false, $_SERVER['REMOTE_ADDR'], $_POST['name'], $_POST['email'], $_POST['content'], $_SESSION['antispam'], $_POST['antispam']);
                     }
-					exit($commentId);
+					exit($commentId); //TODO Not ideal
 				} catch (UserException $e) {
 					header('HTTP/1.1 418 '.$e->getMessage());
 					exit(); //TODO replace this

--- a/Models/Website/User.php
+++ b/Models/Website/User.php
@@ -4,6 +4,7 @@
 namespace VoicesOfWynn\Models\Website;
 
 
+use PDOException;
 use VoicesOfWynn\Models\Db;
 
 class User
@@ -11,7 +12,9 @@ class User
     private const DEFAULT_PASSWORD_CHARACTERS = 'abcdefghijklmnopqrstuvwxyz0123456789';
     public const DEFAULT_PASSWORD_LENGTH = 12;
     private const LOG_PASSWORDS = false; //Turn this on when mass-creating user accounts, so you can message the temporary passwords to users all at once
-    
+
+    private bool $loaded = false;
+
     private int $id = 0;
     private $email = '';
     private string $hash = '';
@@ -27,7 +30,35 @@ class User
     private bool $publicEmail = false;
     
     private array $roles = array();
-    
+
+    /**
+     * Function loading all user information from the database and saving them into attributes
+     * @return void
+     * @throws UserException If this object doesn't have its ID specified (necessary for the database search)
+     */
+    public function load(): void
+    {
+        if (empty($this->id)) {
+            throw new UserException('The User object cannot be loaded, because it doesn\'t have its ID specified.');
+        }
+        $userInfo = (new Db('Website/DbInfo.ini'))->fetchQuery('SELECT * FROM user WHERE user_id = ?', array($this->id));
+
+        $this->id = $userInfo['user_id'];
+        $this->email = $userInfo['email'];
+        $this->hash = $userInfo['password'];
+        $this->systemAdmin = $userInfo['system_admin'];
+        $this->displayName = $userInfo['display_name'];
+        $this->avatarLink = $userInfo['picture'];
+        $this->bio = $userInfo['bio'];
+        $this->discord = $userInfo['discord'];
+        $this->youtube = $userInfo['youtube'];
+        $this->twitter = $userInfo['twitter'];
+        $this->castingcallclub = $userInfo['castingcallclub'];
+        $this->publicEmail = $userInfo['public_email'];
+
+        $this->loaded = true;
+    }
+
     /**
      * Registers a new user account, generates a password and returns it
      * The user is not logged in
@@ -106,6 +137,8 @@ class User
         $this->publicEmail = $userInfo['public_email'];
         
         $_SESSION['user'] = $this;
+
+        $this->loaded = true;
         
         return true;
     }
@@ -173,6 +206,8 @@ class User
 	    $this->twitter = '';
 	    $this->castingcallclub = '';
         $this->publicEmail = false;
+
+        $this->loaded = false;
     }
     
     public function update($email, string $password, string $displayName, string $avatarLink, $bio, $discord, $youtube, $twitter, $castingcallclub, bool $publicEmail): bool
@@ -204,6 +239,8 @@ class User
 		$this->twitter = $twitter;
 		$this->castingcallclub = $castingcallclub;
         $this->publicEmail = $publicEmail;
+
+        $this->loaded = true;
         return $result;
     }
     
@@ -222,6 +259,9 @@ class User
      */
     public function getEmail()
     {
+        if (!$this->loaded && empty($this->email)) {
+            $this->load();
+        }
         return $this->email;
     }
     
@@ -231,6 +271,9 @@ class User
      */
     public function getName(): string
     {
+        if (!$this->loaded && empty($this->displayName)) {
+            $this->load();
+        }
         return $this->displayName;
     }
     
@@ -241,6 +284,9 @@ class User
      */
     public function getAvatarLink(bool $appendRandom = true)
     {
+        if (!$this->loaded && empty($this->avatarLink)) {
+            $this->load();
+        }
         if ($appendRandom && $this->avatarLink !== 'default.png') {
             return $this->avatarLink.'?'.rand(0, 31);
         }
@@ -253,6 +299,9 @@ class User
      */
     public function getBio()
     {
+        if (!$this->loaded && empty($this->bio)) {
+            $this->load();
+        }
         return $this->bio;
     }
     
@@ -262,6 +311,9 @@ class User
      */
     public function getLore()
     {
+        if (!$this->loaded && empty($this->lore)) {
+            $this->load();
+        }
         return $this->lore;
     }
     
@@ -270,15 +322,27 @@ class User
 		$network = strtolower($network);
 		switch ($network) {
 			case 'discord':
+                if (!$this->loaded && empty($this->discord)) {
+                    $this->load();
+                }
 				return $this->discord;
 			case 'youtube':
 			case 'yt':
+                if (!$this->loaded && empty($this->youtube)) {
+                    $this->load();
+                }
 				return $this->youtube;
 			case 'twitter':
+                if (!$this->loaded && empty($this->twitter)) {
+                    $this->load();
+                }
 				return $this->twitter;
 			case 'castingcallclub':
 			case 'casting_call_club':
 			case 'ccc':
+            if (!$this->loaded && empty($this->castingcallclub)) {
+                $this->load();
+            }
 				return $this->castingcallclub;
 			default:
 				return false;
@@ -291,6 +355,9 @@ class User
      */
     public function isSysAdmin(): bool
     {
+        if (!$this->loaded) {
+            $this->load();
+        }
         return $this->systemAdmin;
     }
     
@@ -300,6 +367,9 @@ class User
      */
     public function hasPublicEmail(): bool
     {
+        if (!$this->loaded) {
+            $this->load();
+        }
         return $this->publicEmail;
     }
     
@@ -465,8 +535,20 @@ class User
         ));
     }
 
-    public function resetPassword(): string
+    /**
+     * Resets the password and replaces it with a new temporary, randomly generated one
+     * @param bool $allowForSysadmins Should this functions be able to reset the password of system administrators
+     * @return string The new password
+     * @throws \Exception
+     */
+    public function resetPassword(bool $allowForSysadmins = false): string
     {
+        if (!$allowForSysadmins) {
+            if ($this->isSysAdmin()) {
+                throw new UserException("Password of a system administrator cannot be reset this way for security reasons. Contact Shady#2948 for assistance.");
+            }
+        }
+
         $newPassword = $this->generateTempPassword();
         $db = new Db('Website/DbInfo.ini');
         $this->hash = password_hash($newPassword, PASSWORD_DEFAULT);

--- a/Views/accounts.phtml
+++ b/Views/accounts.phtml
@@ -22,9 +22,10 @@
                 <td id="userinfo"><?= $user->getName() ?></td>
                 <td id="userinfo" style="text-align: left;"><a href="/cast/<?= $user->getId() ?>#bio" target="_blank">Bio User <?= $user->getId() ?></a></td>
                 <td class="buttons-column">
-                    <a href="administration/accounts/<?= $user->getId() ?>/clear-bio"><button class="clearbiobtn">Clear Bio</button></a><br>
-                    <a href="administration/accounts/<?= $user->getId() ?>/clear-avatar"><button class="clearavatarbtn">Clear Avatar</button></a><br>
-                    <a class="delete-account-link" data-user-id=<?= $user->getId() ?>><button class="deletebtn">Delete account</button></a>
+                    <span class="reset-password-link"><button class="resetpasswordbtn">Reset Password</button></span>
+                    <span class="clear-bio-link"><button class="clearbiobtn">Clear Bio</button></span>
+                    <span class="clear-avatar-link"><button class="clearavatarbtn">Clear Avatar</button></span>
+                    <span class="delete-account-link"><button class="deletebtn">Delete account</button></span>
                 </td>
                 <?php for ($i = 0; $i < count(${basename(__FILE__, '.phtml').'_roles'}); $i++) : ?>
                     <td class="role-column" style="background-color: #<?= ${basename(__FILE__, '.phtml').'_roles'}[$i]->color

--- a/css/accounts.css
+++ b/css/accounts.css
@@ -4,11 +4,11 @@
     justify-content: space-around;
 }
 
-.buttons-column>a {
+.buttons-column>span {
     margin: 0!important;
 }
 
-.buttons-column>a>button{
+.buttons-column>span>button{
     font-size: 13px;
     border-radius: 0;
     min-width: 125px;

--- a/css/base.css
+++ b/css/base.css
@@ -188,6 +188,8 @@ textarea { font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sa
 .adminbtn:hover { border-color: rgb(255, 176, 102); }
 .contactbtn { background:rgb(255, 239, 102); }
 .contactbtn:hover { border-color: rgb(239, 228, 143); }
+.resetpasswordbtn { background: rgb(94, 96, 255);}
+.resetpasswordbtn:hover { border-color: rgb(116, 117, 220);}
 .clearbiobtn { background: rgb(247, 225, 32);}
 .clearbiobtn:hover { border-color: rgb(211, 195, 50);}
 .clearavatarbtn { background: rgb(255, 127, 0);}

--- a/js/accounts.js
+++ b/js/accounts.js
@@ -6,8 +6,7 @@ $(".reset-password-link").on('click', function(event) {
         url: "administration/accounts/" + userId + "/reset-password",
         type: 'PUT',
         success: function(result, message, error) {
-            console.log(result);
-            alert("The new password for this user account is:\n" + result + "\nBe sure to send it to the voice actor.\n\nTip: Just screenshot the password and send it as an image, if you don't want to rewrite it.\nI know that it would be great if it was copied automaticaly, but I'm having some issues with implementing that.");
+            alert(result);
         },
         error: function(result, message, error) {
             alert("An error ocurred: " + error);

--- a/js/accounts.js
+++ b/js/accounts.js
@@ -1,22 +1,67 @@
-var $deletingAccount;
+var $affectedAccount;
+
+$(".reset-password-link").on('click', function(event) {
+    let userId = $(event.target).closest("tr").attr("data-user-id");
+    $.ajax({
+        url: "administration/accounts/" + userId + "/reset-password",
+        type: 'PUT',
+        success: function(result, message, error) {
+            console.log(result);
+            alert("The new password for this user account is:\n" + result + "\nBe sure to send it to the voice actor.\n\nTip: Just screenshot the password and send it as an image, if you don't want to rewrite it.\nI know that it would be great if it was copied automaticaly, but I'm having some issues with implementing that.");
+        },
+        error: function(result, message, error) {
+            alert("An error ocurred: " + error);
+        }
+    })
+})
+
+$(".clear-bio-link").on('click', function(event) {
+    let userId = $(event.target).closest("tr").attr("data-user-id");
+    $.ajax({
+        url: "administration/accounts/" + userId + "/clear-bio",
+        type: 'PUT',
+        success: function(result, message, error) {
+            alert("Bio of the user cleared.");
+        },
+        error: function(result, message, error) {
+            alert("An error ocurred: " + error);
+        }
+    })
+});
+
+$(".clear-avatar-link").on('click', function(event) {
+    let userId = $(event.target).closest("tr").attr("data-user-id");
+    $affectedAccount = $(event.target).closest("tr");
+    $.ajax({
+        url: "administration/accounts/" + userId + "/clear-avatar",
+        type: 'PUT',
+        success: function(result, message, error) {
+            $affectedAccount.find(".avatar").attr("src", "dynamic/avatars/default.png");
+            alert("Avatar of the user cleared.");
+        },
+        error: function(result, message, error) {
+            alert("An error ocurred: " + error);
+        }
+    })
+});
 
 $(".delete-account-link").on('click', function(event) {
     if (!confirm("Do you really want to delete this user's account? No recordings or NPC settings will be deleted, but the voice actor of those NPCs will be set to NULL.")) {
         return;
     }
 
-    let userId = $(event.target).attr('data-user-id');
-    $deletingAccount = $(event.target).closest('tr');
+    let userId = $(event.target).closest("tr").attr("data-user-id");
+    $affectedAccount = $(event.target).closest('tr');
 
     $.ajax({
         url: "administration/accounts/" + userId + "/delete",
         type: 'DELETE',
         success: function(result, message, error) {
-            $deletingAccount.remove();
-            $deletingAccount = undefined;
+            $affectedAccount.remove();
+            $affectedAccount = undefined;
         },
         error: function(result, message, error) {
-            $deletingAccount = undefined;
+            $affectedAccount = undefined;
             alert("An error occurred: " + error);
         }
     });

--- a/routes.ini
+++ b/routes.ini
@@ -20,6 +20,7 @@
 /account=Website\Account\Account
 /administration=Website\Administration\Administration?accounts
 /administration/accounts=Website\Administration?accounts
+/administration/accounts/<0>/reset-password=Website\Administration\Administration?accounts?reset-password?<0>
 /administration/accounts/<0>/clear-bio=Website\Administration\Administration?accounts?clear-bio?<0>
 /administration/accounts/<0>/clear-avatar=Website\Administration\Administration?accounts?clear-avatar?<0>
 /administration/accounts/<0>/delete=Website\Administration\Administration?accounts?delete?<0>


### PR DESCRIPTION
There's a new button on the account administration page.
When an admin clicks it, that user's password is replaced with a new, randomly generated temporary password, which is shown to the admin (who then needs to forward it to the user). Password change will be required after using the temporary password to log in.
Passwords of system administrators cannot be reset this way for security reasons. If an admin somehow manages to forget their own password, they'll need to message the webmaster, who will reset the password directly in the database. That should not hopefully ever happen though.

*...right?*