### PR TITLE
Rearranging NPCs' order is now possible

### DIFF
--- a/Controllers/Website/Administration/Npcs.php
+++ b/Controllers/Website/Administration/Npcs.php
@@ -4,22 +4,39 @@ namespace VoicesOfWynn\Controllers\Website\Administration;
 
 use VoicesOfWynn\Controllers\Website\WebpageController;
 use VoicesOfWynn\Models\Website\ContentManager;
+use VoicesOfWynn\Models\Website\NpcRearranger;
 
 class Npcs extends WebpageController
 {
-    
+
     /**
      * @inheritDoc
      */
     public function process(array $args): int
     {
+        if (!empty($args)) {
+            switch ($args[0]) {
+                case 'swap':
+                    $questId = $args[1];
+                    $npc1Id = $args[2];
+                    $npc2Id = $args[3];
+                    $npcRearranger = new NpcRearranger();
+                    $result = $npcRearranger->swap($questId, $npc1Id, $npc2Id);
+                    return ($result) ? 204 : 500;
+                /* More actions can be added here */
+                default:
+                    return 400;
+            }
+        }
+
         self::$data['base_description'] = 'Tool for the administrators to manage NPCs and assign voice actors to them.';
-        
+
         $cnm = new ContentManager();
         self::$data['npcs_quests'] = $cnm->getQuests();
-        
+
+        self::$jsFiles[] = 'npcs';
         self::$views[] = 'npcs';
-        
+
         return true;
     }
 }

--- a/Models/Website/ContentManager.php
+++ b/Models/Website/ContentManager.php
@@ -14,7 +14,7 @@ class ContentManager
 		JOIN npc_quest ON npc_quest.quest_id = quest.quest_id
 		JOIN npc ON npc.npc_id = npc_quest.npc_id
 		LEFT JOIN user ON npc.voice_actor_id = user.user_id
-		ORDER BY quest.quest_id, npc.npc_id;
+		ORDER BY quest.quest_id, npc_quest.sorting_order;
 		';
 		$result = (new Db('Website/DbInfo.ini'))->fetchQuery($query, array(), true);
 		

--- a/Models/Website/NpcRearranger.php
+++ b/Models/Website/NpcRearranger.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace VoicesOfWynn\Models\Website;
+
+use VoicesOfWynn\Models\Db;
+
+class NpcRearranger
+{
+    public function swap(int $questId, int $npc1Id, int $npc2Id): bool
+    {
+        $db = new Db('Website/DbInfo.ini');
+        $db->startTransaction();
+
+        //Brace yourself. You can use this image to combat the code below: https://cdn.discordapp.com/attachments/943819263116988446/1003306660418302032/swap.png
+
+        $db->executeQuery('
+            UPDATE npc_quest SET sorting_order = (
+                (
+                SELECT sorting_order FROM npc_quest WHERE npc_id = ? AND quest_id = ? LIMIT 1
+                ) + sorting_order
+            ) WHERE npc_id = ? AND quest_id = ? LIMIT 1;
+        ', array($npc1Id, $questId, $npc2Id, $questId)); //Addition
+
+        $db->executeQuery('
+            UPDATE npc_quest SET sorting_order = (
+                (
+                SELECT sorting_order FROM npc_quest WHERE npc_id = ? AND quest_id = ? LIMIT 1
+                ) - sorting_order
+            ) WHERE npc_id = ? AND quest_id = ? LIMIT 1;
+        ', array($npc2Id, $questId, $npc1Id, $questId)); //Subtraction 1
+
+        $db->executeQuery('
+            UPDATE npc_quest SET sorting_order = (
+                sorting_order - (
+                SELECT sorting_order FROM npc_quest WHERE npc_id = ? AND quest_id = ? LIMIT 1
+                )
+            ) WHERE npc_id = ? AND quest_id = ? LIMIT 1;
+        ', array($npc1Id, $questId, $npc2Id, $questId)); //Subtraction 2
+
+        return $db->commitTransaction();
+    }
+}
+

--- a/Views/npcs.phtml
+++ b/Views/npcs.phtml
@@ -1,14 +1,19 @@
 <?php foreach (${basename(__FILE__, '.phtml').'_quests'} as $quest) : ?>
-<section>
+<section data-quest-id="<?= $quest->getId() ?>">
 	<h3 style="text-align: center;"><?= $quest->getName() ?></h3>
 	<table class="table-npc-management">
 		<tr>
-			<th></th><th></th><th colspan="2">Voice actor</th><th></th>
+			<th>Rearrange</th><th colspan="2">NPC</th><th colspan="2">Voice actor</th><th></th>
 		</tr>
 	<?php foreach ($quest->getNpcs() as $npc) : ?>
-		<tr>
+		<tr data-npc-id="<?= $npc->getId() ?>">
+            <td>
+                <button class="rearrange-up-btn">🔼</button>
+                <br>
+                <button class="rearrange-down-btn">🔽</button>
+            </td>
 			<td style="min-width: 150px; max-width: 150px;"><img src="dynamic/npcs/<?= $npc->getId() ?>.png" alt="NPC picture" class="avatar" /></td>
-			<td style="min-width: 150px; max-width: 150px;"><?= $npc->getName() ?></td>
+			<td style="min-width: 150px; max-width: 150px;"><a href="contents/npc/<?= $npc->getId() ?>"><?= $npc->getName() ?></a></td>
 			<?php if ($npc->getVoiceActor() === null) : ?>
                 <td style="min-width: 150px; max-width: 150px;"><img class="avatar" src="dynamic/avatars/nobody.png" alt="Profile picture"/></td>
 				<td style="min-width: 150px; max-width: 150px;"><i>Nobody</i></td>

--- a/css/administration.css
+++ b/css/administration.css
@@ -45,3 +45,12 @@ main {
     margin-right:auto;
     max-width:100%;
 }
+
+.rearrange-up-btn, .rearrange-down-btn {
+    border: 0;
+    border-radius: 0;
+    padding: 0;
+}
+.rearrange-up-btn:hover, .rearrange-down-btn:hover {
+    transform: none;
+}

--- a/js/npcs.js
+++ b/js/npcs.js
@@ -1,0 +1,50 @@
+var $moveUpRow;
+var $moveDownRow;
+
+$(".rearrange-up-btn").click(function(event) {
+    $moveUpRow = $(event.target).closest('tr');
+    $moveDownRow = $(event.target).closest('tr').prev();
+    if ($moveDownRow.attr('data-npc-id') === undefined) {
+        alert("This NPC can't be moved any higher.");
+        return;
+    }
+
+    let questId = $moveUpRow.closest('section').attr('data-quest-id');
+    let npc1Id = $moveUpRow.attr('data-npc-id');
+    let npc2Id = $moveDownRow.attr('data-npc-id');
+
+    $.ajax({
+        url: "administration/npcs/swap/" + questId + "/" + npc1Id + "/" + npc2Id,
+        type: 'PUT',
+        success: function(result, message, error) {
+            $moveDownRow.insertAfter($moveUpRow);
+        },
+        error: function(result, message, error) {
+            alert("An error ocurred: " + error);
+        }
+    })
+});
+
+$(".rearrange-down-btn").click(function(event) {
+    $moveDownRow = $(event.target).closest('tr');
+    $moveUpRow = $(event.target).closest('tr').next();
+    if ($moveUpRow.attr('data-npc-id') === undefined) {
+        alert("This NPC can't be moved any lower.");
+        return;
+    }
+
+    let questId = $moveUpRow.closest('section').attr('data-quest-id');
+    let npc1Id = $moveUpRow.attr('data-npc-id');
+    let npc2Id = $moveDownRow.attr('data-npc-id');
+
+    $.ajax({
+        url: "administration/npcs/swap/" + questId + "/" + npc1Id + "/" + npc2Id,
+        type: 'PUT',
+        success: function(result, message, error) {
+            $moveDownRow.insertAfter($moveUpRow);
+        },
+        error: function(result, message, error) {
+            alert("An error ocurred: " + error);
+        }
+    })
+});

--- a/routes.ini
+++ b/routes.ini
@@ -28,6 +28,7 @@
 /administration/accounts/<0>/update-roles/revoke/<1>=Website\Administration\Administration?accounts?revoke-role?<0>?<1>
 /administration/new-account=Website\Administration\Administration?new-account
 /administration/npcs=Website\Administration\Administration?npcs
+/administration/npcs/swap/<0>/<1>/<2>=Website\Administration\Administration?npcs?swap?<0>?<1>?<2>
 /administration/npcs/manage/<0>=Website\Administration\Administration?npc?<0>?false
 /administration/npcs/manage/<0>/delete/<1>=Website\Administration\Administration?npc?<0>?false?<1>
 /administration/npcs/manage/<0>/recast/<1>=Website\Administration\Administration?npc?<0>?false?<1>


### PR DESCRIPTION
On the "Manage NPCs" page, there are now 🔼🔽 buttons that can be clicked to move the NPC up or down one position.

The database table `npc_quest` now has one new column, so an update is required for all developers. The export file will be sent via e-mail.

Resolved #77 