### PR TITLE
NPCs can now be archived to quickly handle large quest updates

### DIFF
--- a/Controllers/Website/Npc.php
+++ b/Controllers/Website/Npc.php
@@ -145,22 +145,29 @@ class Npc extends WebpageController
             return 403;
         }
 
+        if (empty($this->npc)) {
+            return 400;
+        }
+
         switch (array_shift($args)) {
             case 'recast':
                 $user = new User();
                 $user->setData(array('id' => array_shift($args)));
-                if (empty($this->npc->getId()) || empty($user)) {
+                if (empty($user)) {
                     return 400;
                 }
                 $result = $this->npc->recast($user);
                 return ($result) ? 204 : 500;
-                break;
             case 'archive':
-                //TODO
-                break;
+                $result = $this->npc->archive();
+                return ($result) ? 201 : 500;
             case 'archive-quest-recordings':
-                //TODO
-                break;
+                $questId = array_shift($args);
+                if (empty($questId)) {
+                    return 400;
+                }
+                $result = $this->npc->archiveQuestRecordings($questId);
+                return ($result) ? 204 : 500;
             default:
                 return 400;
         }

--- a/Controllers/Website/Npc.php
+++ b/Controllers/Website/Npc.php
@@ -160,7 +160,10 @@ class Npc extends WebpageController
                 return ($result) ? 204 : 500;
             case 'archive':
                 $result = $this->npc->archive();
-                return ($result) ? 201 : 500;
+                header('Content-Type: application/json');
+                header('HTTP/1.1 303 See Other');
+                echo json_encode(array('Location' => '/administration/npcs/manage/'.$result));
+                return ($result) ? 303 : 500;
             case 'archive-quest-recordings':
                 $questId = array_shift($args);
                 if (empty($questId)) {

--- a/Controllers/Website/WebpageController.php
+++ b/Controllers/Website/WebpageController.php
@@ -151,6 +151,7 @@ abstract class WebpageController extends Controller
                     $attr = array();
                     $attr['id'] = $this->sanitize($value->getId());
                     $attr['name'] = $this->sanitize($value->getName());
+                    $attr['archived'] = $this->sanitize($value->isArchived());
                     $voiceActor = $this->sanitize($value->getVoiceActor());
                     $npc = new Npc($attr);
                     if ($voiceActor !== null) {
@@ -172,6 +173,7 @@ abstract class WebpageController extends Controller
                     $attr['upvotes'] = $this->sanitize($value->upvotes);
                     $attr['downvotes'] = $this->sanitize($value->downvotes);
                     $attr['comments'] = $this->sanitize($value->comments);
+                    $attr['archived'] = $this->sanitize($value->archived);
                     $return = new Recording($attr);
                 }
                 else if ($value instanceof Comment) {

--- a/Models/Db.php
+++ b/Models/Db.php
@@ -70,11 +70,11 @@ class Db
     /**
      * Execute a query that doesn't return any data (suitable for INSERT, UPDATE and DELETE queries)
      * @param string $query The query to execute, variables to insert need to be replaced with '?'
-     * @param array $parameters Variables that should replaces the '?'s in the query
+     * @param array $parameters Variables that should replace the '?'s in the query
      * @param bool $returnLastId TRUE, if the ID of the last inserted row should be returned instead of true/false
      * @return bool|string TRUE on success, FALSE on failure; in case the last parameter is set to TRUE, the ID of the
      * inserter row is returned
-     * @throws Exception In case of a database error
+     * @throws PDOException In case of a database error
      */
     public function executeQuery(string $query, array $parameters = array(), bool $returnLastId = false)
     {

--- a/Models/Website/ContentManager.php
+++ b/Models/Website/ContentManager.php
@@ -133,7 +133,7 @@ class ContentManager
 		FROM recording
 		JOIN quest USING(quest_id)
 		JOIN npc USING(npc_id)
-		WHERE npc.voice_actor_id = ?
+		WHERE npc.voice_actor_id = ? AND recording.archived = 0
 		ORDER BY quest_id, line;';
 		$result = (new Db('Website/DbInfo.ini'))->fetchQuery($query, array($id), true);
 		
@@ -171,7 +171,7 @@ class ContentManager
 		SELECT recording.recording_id, recording.quest_id, recording.line, recording.file, recording.upvotes, recording.downvotes, (SELECT COUNT(*) FROM comment WHERE comment.recording_id = recording.recording_id) AS "comments", quest.name
 		FROM recording
 		JOIN quest ON quest.quest_id = recording.quest_id
-		WHERE npc_id = ?
+		WHERE npc_id = ? AND archived = 0
 		ORDER BY quest_id, line;';
 		$result = $db->fetchQuery($query, array($id), true);
 		

--- a/Models/Website/Npc.php
+++ b/Models/Website/Npc.php
@@ -3,6 +3,7 @@
 namespace VoicesOfWynn\Models\Website;
 
 use \JsonSerializable;
+use VoicesOfWynn\Models\Db;
 
 class Npc implements JsonSerializable
 {
@@ -33,7 +34,7 @@ class Npc implements JsonSerializable
 		}
 	}
 	
-	public function jsonSerialize()
+	public function jsonSerialize() : object
 	{
 	    return (object) get_object_vars($this);
 	}
@@ -42,16 +43,29 @@ class Npc implements JsonSerializable
 	 * VoiceActor setter
 	 * @param User $voiceActor
 	 */
-	public function setVoiceActor(User $voiceActor)
+	public function setVoiceActor(User $voiceActor) : void
 	{
 		$this->voiceActor = $voiceActor;
 	}
-	
+
+    /**
+     * Method setting a new voice actor and updating the database
+     * @param User $voiceActor
+     * @return bool Whether the database query has successfully been executed
+     */
+    public function recast(User $voiceActor) : bool
+    {
+        $this->setVoiceActor($voiceActor);
+
+        //Update the database
+        return (new Db('Website/DbInfo.ini'))->executeQuery('UPDATE npc SET voice_actor_id = ? WHERE npc_id = ? LIMIT 1;', array($voiceActor->getId(), $this->id));
+    }
+
 	/**
 	 * ID getter
 	 * @return int|null ID of this NPC or NULL if it wasn't set
 	 */
-	public function getId()
+	public function getId() : ?int
 	{
 		return $this->id;
 	}
@@ -60,7 +74,7 @@ class Npc implements JsonSerializable
 	 * Name getter
 	 * @return string|null Name of this NPC or NULL if it wasn't set
 	 */
-	public function getName()
+	public function getName() : ?string
 	{
 		return $this->name;
 	}
@@ -69,7 +83,7 @@ class Npc implements JsonSerializable
 	 * VoiceActor getter
 	 * @return User|null Object representing the user voicing this NPC or NULL if it wasn't set
 	 */
-	public function getVoiceActor()
+	public function getVoiceActor() : ?User
 	{
 		return $this->voiceActor;
 	}
@@ -78,7 +92,7 @@ class Npc implements JsonSerializable
 	 * Method adding a Recording object to this NPC's $recordings attribute
 	 * @param Recording $recording The Recording object to add
 	 */
-	public function addRecording(Recording $recording)
+	public function addRecording(Recording $recording) : void
 	{
 		$this->recordings[] = $recording;
 	}
@@ -87,7 +101,7 @@ class Npc implements JsonSerializable
 	 * Recordings getter
 	 * @return array
 	 */
-	public function getRecordings()
+	public function getRecordings() : array
 	{
 		return $this->recordings;
 	}

--- a/Models/Website/Recording.php
+++ b/Models/Website/Recording.php
@@ -288,7 +288,7 @@ class Recording
 
         //Update the database
         $db = new Db('Website/DbInfo.ini');
-        return $db->executeQuery('UPDATE recording SET archived = 1, file = ? WHERE recording_id = ?;', array($this->file, $this->id));
+        return $db->executeQuery('UPDATE recording SET archived = TRUE, file = ? WHERE recording_id = ?;', array($this->file, $this->id));
     }
 }
 

--- a/Views/cast.phtml
+++ b/Views/cast.phtml
@@ -72,9 +72,12 @@
         <section>
             <table>
                 <tr>
-                  <th colspan="5">
-                      <b><?= $quest->getNpcs()[0]->getName() ?></b> in <i><?= $quest->getName() ?></i>
-                  </th>
+                    <th colspan="5">
+                        <b><?= $quest->getNpcs()[0]->getName() ?></b> in <i><?= $quest->getName() ?></i>
+                        <?php if ($quest->getNpcs()[0]->isArchived()) : ?>
+                            (outdated)
+                        <?php endif ?>
+                    </th>
                 </tr>
                 <?php $recordings = $quest->getNpcs()[0]->getRecordings(); ?>
                 <?php foreach ($recordings as $recording) : ?>

--- a/Views/npc.phtml
+++ b/Views/npc.phtml
@@ -36,6 +36,7 @@
             </select>
             <input type="submit" value="Confirm" id="va-confirm-change"/>
         </form>
+        <p class="txt-c mb-l"><button id="archive-btn">Archive</button></p>
         <hr class="hr-f">
     <?php endif ?>
 </p>
@@ -76,6 +77,7 @@
         </tr>
         <?php endforeach ?>
     </table>
+    <p class="txt-c mb-l"><button class="archive-all-recordings-btn" data-quest-id="<?= $quest->getId() ?>">Archive all recordings</button></p>
     <?php if (${basename(__FILE__, '.phtml').'_admin'}) : ?>
         <form method="post" enctype="multipart/form-data" class="new-recording-form">
             <h4>Add new recording</h4>

--- a/Views/npc.phtml
+++ b/Views/npc.phtml
@@ -47,7 +47,7 @@
 <div class="reccenter">
 <section class="table-center">
     <table>
-        <tr>
+        <tr class="recordings-table-quest-header">
             <th colspan="<?php if (${basename(__FILE__, '.phtml').'_admin'}) : ?>6<?php else : ?>5<?php endif ?>"><?= $quest->getName() ?></th>
         </tr>
 	    <?php $recordings = $quest->getNpcs()[0]->getRecordings(); ?>

--- a/Views/npc.phtml
+++ b/Views/npc.phtml
@@ -1,6 +1,11 @@
 <script>var npcId = <?= ${basename(__FILE__, '.phtml').'_npc'}->getId() ?>;</script>
 
-<h1 class="mb-l"><?= ${basename(__FILE__, '.phtml').'_npc'}->getName() ?></h1>
+<h1 class="mb-l">
+    <?= ${basename(__FILE__, '.phtml').'_npc'}->getName() ?>
+    <?php if (${basename(__FILE__, '.phtml').'_npc'}->isArchived()) : ?>
+     (outdated)
+    <?php endif ?>
+</h1>
 
 <p class="npc-va-center-img txt-c mb-l">
     <img class="avatar" src="dynamic/npcs/<?= ${basename(__FILE__, '.phtml').'_npc'}->getId() ?>.png" alt="NPC picture" width="200px" height="200px"/>

--- a/css/npc.css
+++ b/css/npc.css
@@ -1,3 +1,11 @@
+#change-actor-btn { background: rgb(255, 204, 0);}
+#change-actor-btn:hover { border-color: rgb(210, 176, 43); }
+
+#archive-btn { background: rgb(140, 140, 140);}
+#archive-btn:hover { border-color: rgb(197, 16, 16); }
+
+.archive-all-recordings-btn { background: rgb(255, 79, 79);}
+.archive-all-recordings-btn:hover  { border-color: rgb(187, 79, 79);}
 
 #voice-actor-form {
     display: none;

--- a/index.php
+++ b/index.php
@@ -39,6 +39,8 @@ $requestedUrl = $_SERVER['REQUEST_URI'];
 //Process the request
 $router = new Router();
 $result = $router->process(array($requestedUrl));
+
+$website = '';
 if ($result >= 400) {
     //Display the error webpage, overwrite the page headers (title, description, keywords)
     $errorControllerName = "VoicesOfWynn\Controllers\Errors\Error".$result;
@@ -48,17 +50,13 @@ if ($result >= 400) {
     if ($router->isWebpageRequest) {
         $website = $errorController->getResult();
     }
-    else {
-        $website = '';
-    }
 }
 else if ($result === 204) {
     header('HTTP/1.1 204 No Content');
     //Don't render any views, simply don't echo anything into the response body
     //This is mostly used for AJAX calls
-    $website = '';
 }
-else {
+else if ($result < 300) {
     $website = $router->getResult();
 }
 

--- a/index.php
+++ b/index.php
@@ -53,6 +53,7 @@ if ($result >= 400) {
     }
 }
 else if ($result === 204) {
+    header('HTTP/1.1 204 No Content');
     //Don't render any views, simply don't echo anything into the response body
     //This is mostly used for AJAX calls
     $website = '';

--- a/js/npc.js
+++ b/js/npc.js
@@ -58,7 +58,22 @@ $("#archive-btn").on('click', function() {
         return;
     }
 
-    //TODO
+    $.ajax({
+        url: "/administration/npcs/manage/" + npcId + "/archive",
+        type: 'PUT',
+        success: function(result, message) { /* Shouldn't happen */ },
+        error: function(result, message, error) {
+            if (error === "See Other") {
+                //Actually success
+                if (confirm('This NPC has successfully been archived and a new one was created.\n\nWould you like to go to the new NPC\'s administration page?')) {
+                    window.location = JSON.parse(result.responseText).Location;
+                }
+                return;
+            }
+
+            alert("An error occurred: " + error);
+        }
+    });
 });
 
 
@@ -107,6 +122,7 @@ $(".archive-all-recordings-btn").on('click', function(event) {
         },
         error: function(result, message, error) {
             alert("An error occurred: " + error);
+            $archivingRecordings = undefined;
         }
     });
 });

--- a/js/npc.js
+++ b/js/npc.js
@@ -1,3 +1,4 @@
+var voiceActorId;
 var voiceActorName;
 var voiceActorAvatar;
 // var npcId; - filled by PHP in the view
@@ -14,14 +15,25 @@ $("#change-actor-btn").on('click', toggleRecastingButton);
 
 $("#voice-actor-form").on('submit', function(event) {
     event.preventDefault();
+    if (!confirm('Are you sure you want to recast this character?\n' +
+        '\n' +
+        'If there are any recordings by the original voice actor, you should archive this NPC instead.\n' +
+        'Archiving an NPC will create a new one without any recordings and replace this one with it.\n' +
+        'You\'ll be able to upload new recordings without deleting the current ones and nothing will be lost.\n' +
+        '\n' +
+        'Recasting should be done only in the case of the original voice actor not submitting their lines or not getting their voice in the mod for other reasons.')) {
+        return;
+    }
+    voiceActorId = $(event.target).find("select").val();
     voiceActorName = $(event.target).find('select option:selected').text();
     voiceActorAvatar = $(event.target).find('select option:selected').attr('data-avatar-link');
     $.ajax({
-        url: "administration/npcs/manage/" + npcId + "/recast/" + $(event.target).find("select").val(),
+        url: "administration/npcs/manage/" + npcId + "/recast/" + voiceActorId,
         type: 'PUT',
         success: function(result, message) {
             $("#voice-actor-avatar").attr('src', 'dynamic/avatars/' + voiceActorAvatar);
             $("#voice-actor-name").text(voiceActorName);
+            $(".valink").attr("href", "cast/" + voiceActorId)
             toggleRecastingButton();
         },
         error: function(result, message, error) {
@@ -29,6 +41,26 @@ $("#voice-actor-form").on('submit', function(event) {
         }
     });
 });
+
+//-----------------------------------ARCHIVING SECTION-----------------------------------
+
+$("#archive-btn").on('click', function() {
+    if (!confirm('Are you sure you want to archive this NPC?\n' +
+        'THIS IS A DESTRUCTIVE ACTION WHICH CANNOT BE UNDONE WITHOUT WEBMASTER\'S ASSISTANCE\n' +
+        '\n' +
+        'Archiving an NPC will unlink it from its quest and so this webpage will no longer be accessible by browsing the "Mod contents" page.\n' +
+        'All recording files of this NPC will be renamed on the server to indicate, that they belong to an archived NPC.\n' +
+        'At the same time, a new NPC object will be created, with the same name and profile picture, but without any recordings or voice actor.\n' +
+        'This "empty" NPC will then replace this one and will be accessible on the "Mod contents" page.\n' +
+        '\n' +
+        'This option should be used only in case the quest got a rework and this NPC has been severely altered or removed, or in case of an recast.'
+    )) {
+        return;
+    }
+
+    //TODO
+});
+
 
 //------------------------------DELETING RECORDINGS SECTION------------------------------
 
@@ -52,28 +84,29 @@ $(".delete-recording-btn").on('click', function(event){
     });
 });
 
-//------------------------------UPLOADING RECORDINGS SECTION------------------------------
+$(".archive-all-recordings-btn").on('click', function(event) {
+    if (!confirm('Are you sure you want to archive all recordings of this NPC in this quest?\n' +
+        'THIS IS A DESTRUCTIVE ACTION WHICH CANNOT BE UNDONE WITHOUT WEBMASTER\'S ASSISTANCE\n' +
+        '\n' +
+        'All the recordings listed above will be hidden from public view, but will still be accessible by entering a direct link.\n' +
+        'No comments will be lost and the files on the server will be renamed to indicate that they contain an archived recording.\n' +
+        '\n' +
+        'This option should be used only in the case the dialogue receives a large revamp and is revoiced by the original voice actor.')) {
+        return;
+    }
 
-var recordingItemHtml = '<tr class="new-recording-item"><td><input name="recording{NUM}" type="file" accept="application/ogg" class="recording-input" required/></td><td><input name="line{NUM}" type="number" min="1" max="32767" value="{LINE}" class="line-input" required/></td></tr>';
-
-function toggleAddingButton(event)
-{
-    $(event.target).closest('.new-recording-form').find('.add-more-recordings-button').toggle();
-}
-
-$(".recording-input").on('change', toggleAddingButton);
-
-$(".add-more-recordings-button").on('click', function(event) {
-    event.preventDefault();
-    let item = recordingItemHtml;
-    let num = $(event.target).parent().find('.new-recording-items-container').children().length; //Header row included - we start from 1 anyway
-    num++;
-    let line = $(event.target).parent().find('.new-recording-items-container').children().last().find('.line-input').val();
-    line++;
-    item = item.replace(/{NUM}/g, num);
-    item = item.replace(/{LINE}/g, line);
-    $(event.target).parent().find('.new-recording-items-container').children().last().find('.recording-input').off('change');
-    $(event.target).parent().find('.new-recording-items-container').append(item);
-    $(event.target).parent().find('.new-recording-items-container').children().last().find('.recording-input').on('change', toggleAddingButton);
-    $(event.target).hide();
+    //TODO
+    let questId = $(event.target).attr('data-quest-id');
+    $.ajax({
+        url: "administration/npcs/manage/" + npcId + "/recast/" + $(event.target).find("select").val(),
+        type: 'PUT',
+        success: function(result, message) {
+            $("#voice-actor-avatar").attr('src', 'dynamic/avatars/' + voiceActorAvatar);
+            $("#voice-actor-name").text(voiceActorName);
+            toggleRecastingButton();
+        },
+        error: function(result, message, error) {
+            alert("An error occurred: " + error);
+        }
+    });
 });

--- a/js/npc.js
+++ b/js/npc.js
@@ -84,6 +84,8 @@ $(".delete-recording-btn").on('click', function(event){
     });
 });
 
+var $archivingRecordings;
+
 $(".archive-all-recordings-btn").on('click', function(event) {
     if (!confirm('Are you sure you want to archive all recordings of this NPC in this quest?\n' +
         'THIS IS A DESTRUCTIVE ACTION WHICH CANNOT BE UNDONE WITHOUT WEBMASTER\'S ASSISTANCE\n' +
@@ -95,15 +97,13 @@ $(".archive-all-recordings-btn").on('click', function(event) {
         return;
     }
 
-    //TODO
     let questId = $(event.target).attr('data-quest-id');
+    $archivingRecordings = $(event.target).closest('.table-center').find('tr:not(.recordings-table-quest-header)');
     $.ajax({
-        url: "administration/npcs/manage/" + npcId + "/recast/" + $(event.target).find("select").val(),
+        url: "administration/npcs/manage/" + npcId + "/archive-quest-recordings/" + questId,
         type: 'PUT',
         success: function(result, message) {
-            $("#voice-actor-avatar").attr('src', 'dynamic/avatars/' + voiceActorAvatar);
-            $("#voice-actor-name").text(voiceActorName);
-            toggleRecastingButton();
+            $archivingRecordings.remove();
         },
         error: function(result, message, error) {
             alert("An error occurred: " + error);

--- a/routes.ini
+++ b/routes.ini
@@ -36,7 +36,7 @@
 /administration/npcs/manage/<0>=Website\Administration\Administration?npc?<0>?false
 /administration/npcs/manage/<0>/delete/<1>=Website\Administration\Administration?npc?<0>?false?<1>
 /administration/npcs/manage/<0>/recast/<1>=Website\Administration\Administration?npc?<0>?false?recast?<1>
-/administration/npcs/manage/<0>/archive=Website\Administration\Administration?npc?<0>?archive?false
+/administration/npcs/manage/<0>/archive=Website\Administration\Administration?npc?<0>?false?archive
 /administration/npcs/manage/<0>/archive-quest-recordings/<1>=Website\Administration\Administration?npc?<0>?false?archive-quest-recordings?<1>
 /logout=Website\Account\Logout
 

--- a/routes.ini
+++ b/routes.ini
@@ -36,8 +36,8 @@
 /administration/npcs/manage/<0>=Website\Administration\Administration?npc?<0>?false
 /administration/npcs/manage/<0>/delete/<1>=Website\Administration\Administration?npc?<0>?false?<1>
 /administration/npcs/manage/<0>/recast/<1>=Website\Administration\Administration?npc?<0>?false?recast?<1>
-/administration/npcs/manage/<0>/archive=Website\Administration\Administration?npc?<0>?false
-/administration/npcs/manage/<0>/archive-quest-recordings/<1>=Website\Administration\Administration?npc?<0>?false?<1>
+/administration/npcs/manage/<0>/archive=Website\Administration\Administration?npc?<0>?archive?false
+/administration/npcs/manage/<0>/archive-quest-recordings/<1>=Website\Administration\Administration?npc?<0>?false?archive-quest-recordings?<1>
 /logout=Website\Account\Logout
 
 ; API routes

--- a/routes.ini
+++ b/routes.ini
@@ -35,7 +35,9 @@
 /administration/npcs/swap/<0>/<1>/<2>=Website\Administration\Administration?npcs?swap?<0>?<1>?<2>
 /administration/npcs/manage/<0>=Website\Administration\Administration?npc?<0>?false
 /administration/npcs/manage/<0>/delete/<1>=Website\Administration\Administration?npc?<0>?false?<1>
-/administration/npcs/manage/<0>/recast/<1>=Website\Administration\Administration?npc?<0>?false?<1>
+/administration/npcs/manage/<0>/recast/<1>=Website\Administration\Administration?npc?<0>?false?recast?<1>
+/administration/npcs/manage/<0>/archive=Website\Administration\Administration?npc?<0>?false
+/administration/npcs/manage/<0>/archive-quest-recordings/<1>=Website\Administration\Administration?npc?<0>?false?<1>
 /logout=Website\Account\Logout
 
 ; API routes


### PR DESCRIPTION
Archiving an NPC preserves all the original data, like recordings and comments, but unlinks the NPC from the publically visible quest, so it can no longer be accessed by clicking a link anywhere on the website (currently). It can only be accessed by entering a direct URL.

Recordings from individual quests and NPCs can also be archived individually (like the batch of the recordings of an NPC in one quest). These recordings will also be hidden, but the NPC will remain the same.

Read phpDoc for more information, JavaScript alerts are quite explainatory themselves.