### PR TITLE
Updates for to make kmaxi's job easier

### DIFF
--- a/Controllers/Api/LineReporting/LineReporter.php
+++ b/Controllers/Api/LineReporting/LineReporter.php
@@ -33,6 +33,8 @@ class LineReporter extends ApiController
                 return $this->getAcceptedLines();
             case 'getActiveReports':
                 return $this->getNonRejectedLines();
+            case 'getValidReports':
+                return $this->getValidNpcLines();
             default:
                 return 400;
         }
@@ -169,6 +171,29 @@ class LineReporter extends ApiController
             $npcName = $_GET['npc'];
         }
         $responseCode = $reportReader->getReportsByNpc($npcName, array('accepted', 'forwarded', 'unprocessed'));
+        if ($responseCode >= 400) {
+            //An error occurred
+            return $responseCode;
+        }
+        $reports = $reportReader->result;
+        echo json_encode($reports, JSON_PRETTY_PRINT);
+        return 200;
+    }
+
+    private function getValidNpcLines(): int
+    {
+        if ($_SERVER['REQUEST_METHOD'] !== 'GET') {
+            return 405;
+        }
+        if ($_REQUEST['apiKey'] !== self::COLLECTING_API_KEY) {
+            return 401;
+        }
+        $reportReader = new ReportReader();
+        $npcName = null;
+        if (isset($_GET['npc'])) {
+            $npcName = $_GET['npc'];
+        }
+        $responseCode = $reportReader->getReportsByNpc($npcName, array('voiced', 'accepted', 'forwarded', 'unprocessed'));
         if ($responseCode >= 400) {
             //An error occurred
             return $responseCode;

--- a/Controllers/Website/Account/Account.php
+++ b/Controllers/Website/Account/Account.php
@@ -5,10 +5,16 @@ namespace VoicesOfWynn\Controllers\Website\Account;
 
 use VoicesOfWynn\Controllers\Website\WebpageController;
 use VoicesOfWynn\Models\Website\AccountDataValidator;
+use VoicesOfWynn\Models\Website\User;
 
 class Account extends WebpageController
 {
-    
+
+    /**
+     * @var User The user object that we're editing
+     */
+    private User $user;
+
     /**
      * @inheritDoc
      */
@@ -18,7 +24,25 @@ class Account extends WebpageController
             //No user is logged in
             return 401;
         }
-        
+
+        $userId = $args[0];
+        array_shift($args);
+        if ($userId === 'self') {
+            //Editing logged-in user's profile
+            $this->user = $_SESSION['user'];
+        } else {
+            //Editing somebody else's profile
+            //Check whether the logged-in user is a system administrator
+            if (!$_SESSION['user']->isSysAdmin()) {
+                //The logged user is not system admin
+                return 403;
+            }
+
+            $this->user = new User();
+            $this->user->setData(array('id' => $userId));
+            $this->user->load();
+        }
+
         switch ($_SERVER['REQUEST_METHOD']) {
             case 'GET':
                 return $this->get(array());
@@ -28,7 +52,7 @@ class Account extends WebpageController
 	        	return 405;
         }
     }
-    
+
     /**
      * Processing method for GET requests to this controller (account info form was requested)
      * @param array $args
@@ -39,30 +63,30 @@ class Account extends WebpageController
         self::$data['base_title'] = 'Your Account';
         self::$data['base_description'] = 'Here, you can change the information about you, that is publicly visible.';
         self::$data['base_keywords'] = 'Minecraft,Wynncraft,Mod,Voice,Account,Management';
-        
-        self::$data['account_id'] = $_SESSION['user']->getId();
-	    self::$data['account_name'] = $_SESSION['user']->getName();
-        self::$data['account_email'] = $_SESSION['user']->getEmail();
-        self::$data['account_publicEmail'] = $_SESSION['user']->hasPublicEmail();
-		self::$data['account_discord'] = $_SESSION['user']->getSocial('discord');
-		self::$data['account_youtube'] = $_SESSION['user']->getSocial('youtube');
-		self::$data['account_twitter'] = $_SESSION['user']->getSocial('twitter');
-		self::$data['account_castingcallclub'] = $_SESSION['user']->getSocial('castingcallclub');
-        self::$data['account_picture'] = $_SESSION['user']->getAvatarLink();
-        self::$data['account_roles'] = $_SESSION['user']->getRoles();
-        self::$data['account_bio'] = $_SESSION['user']->getBio();
+
+        self::$data['account_id'] = $this->user->getId();
+	    self::$data['account_name'] = $this->user->getName();
+        self::$data['account_email'] = $this->user->getEmail();
+        self::$data['account_publicEmail'] = $this->user->hasPublicEmail();
+		self::$data['account_discord'] = $this->user->getSocial('discord');
+		self::$data['account_youtube'] = $this->user->getSocial('youtube');
+		self::$data['account_twitter'] = $this->user->getSocial('twitter');
+		self::$data['account_castingcallclub'] = $this->user->getSocial('castingcallclub');
+        self::$data['account_picture'] = $this->user->getAvatarLink();
+        self::$data['account_roles'] = $this->user->getRoles();
+        self::$data['account_bio'] = $this->user->getBio();
         if (empty(self::$data['account_error'])) {
             self::$data['account_error'] = array();
         }
-        
+
         self::$views[] = 'account';
         self::$cssFiles[] = 'account';
         self::$jsFiles[] = 'account';
         self::$jsFiles[] = 'tinymce_bio';
-        
+
         return true;
     }
-    
+
     /**
      * Processing method for POST requests to this controller (account info was updated)
      * @param array $args
@@ -79,57 +103,57 @@ class Account extends WebpageController
 	    $twitter = $_POST['twitter'];
 	    $castingcallclub = $_POST['castingcallclub'];
         $bio = $_POST['bio'];
-        
+
         $validator = new AccountDataValidator();
-		
+
         $validator->validateName($displayName);
-		
+
         if (!empty($password)) {
             $validator->validatePassword($password);
         }
-	
+
 	    if (!empty($email)) {
 		    $validator->validateEmail($email);
 	    }
 	    else {
 		    $email = null;
 	    }
-	
+
 	    if (!empty($discord)) {
 		    $validator->validateDiscord($discord);
 	    }
 	    else {
 		    $discord = null;
 	    }
-	
+
 	    if (!empty($youtube)) {
 		    $validator->validateYouTubeLink($youtube);
 	    }
 	    else {
 		    $youtube = null;
 	    }
-	
+
 	    if (!empty($twitter)) {
 		    $validator->validateTwitter($twitter);
 	    }
 	    else {
 		    $twitter = null;
 	    }
-	
+
 	    if (!empty($castingcallclub)) {
 		    $validator->validateCastingCallClub($castingcallclub);
 	    }
 	    else {
 		    $castingcallclub = null;
 	    }
-		
+
 	    $bio = $validator->sanitizeBio($bio);
 		$validator->validateBio($bio);
-		
+
         if ($_FILES['avatar']['error'] !== UPLOAD_ERR_NO_FILE) {
             $validator->validateAvatar($_FILES['avatar']);
-        
-            $avatar = $_SESSION['user']->getId();
+
+            $avatar = $this->user->getId();
             switch ($_FILES['avatar']['type']) {
                 case 'image/jpeg':
                     $avatar .= '.jpg';
@@ -139,23 +163,23 @@ class Account extends WebpageController
                     break;
             }
         }
-        
+
         if (empty($validator->errors)) {
             if ($_FILES['avatar']['error'] !== UPLOAD_ERR_NO_FILE) {
                 //Delete old avatars
-                array_map('unlink', glob('dynamic/avatars/'.$_SESSION['user']->getId().'.*'));
-                
+                array_map('unlink', glob('dynamic/avatars/'.$this->user->getId().'.*'));
+
                 //Save changes
                 move_uploaded_file($_FILES['avatar']['tmp_name'], 'dynamic/avatars/'.$avatar);
             } else {
-                $avatar = $_SESSION['user']->getAvatarLink(false);
+                $avatar = $this->user->getAvatarLink(false);
             }
-            
-            $_SESSION['user']->update($email, $password, $displayName, $avatar, $bio, $discord, $youtube, $twitter, $castingcallclub, $publicEmail);
+
+            $this->user->update($email, $password, $displayName, $avatar, $bio, $discord, $youtube, $twitter, $castingcallclub, $publicEmail);
         }
-    
+
         $result = $this->get(array());
-    
+
         self::$data['account_name'] = $displayName;
 	    self::$data['account_email'] = $email;
 	    self::$data['account_discord'] = $discord;
@@ -165,7 +189,7 @@ class Account extends WebpageController
         //TODO - somhow keep the new and unsaved avatar
         self::$data['account_bio'] = $bio;
 	    self::$data['account_error'] = array_merge($validator->errors, $validator->warnings);
-        
+
         return $result;
     }
 }

--- a/Controllers/Website/Administration/NewAccount.php
+++ b/Controllers/Website/Administration/NewAccount.php
@@ -29,6 +29,7 @@ class NewAccount extends WebpageController
         self::$data['base_description'] = 'Tool for the administrators to create new accounts for new contributors.';
         
         self::$data['newaccount_password'] = '';
+        self::$data['newaccount_userId'] = 0;
         self::$data['newaccount_error'] = '';
         
         self::$views[] = 'new-account';
@@ -41,8 +42,9 @@ class NewAccount extends WebpageController
         
         $user = new User();
         try {
-            $password = $user->register($_POST['name'], $_POST['discord'], true);
+            $password = $user->register($_POST['name'], $_POST['discord'], $_POST['ccc'], true);
             self::$data['newaccount_password'] = $password;
+            self::$data['newaccount_userId'] = $user->getId();
         } catch (UserException $e) {
             self::$data['newaccount_error'] = $e->getMessage();
         }

--- a/Views/accounts.phtml
+++ b/Views/accounts.phtml
@@ -23,6 +23,7 @@
                 <td class="userinfo" class="txt-l"><a href="/cast/<?= $user->getId() ?>#bio" target="_blank">Bio User <?= $user->getId() ?></a></td>
                 <td class="buttons-column">
                     <span class="reset-password-link"><button class="resetpasswordbtn" class="lb-a">Reset Password</button></span>
+                    <a class="manage-account-link" href="/account/<?= $user->getId() ?>"><button class="manageaccbtn" class="lb-a">Manage Account</button></a>
                     <span class="clear-bio-link"><button class="clearbiobtn" class="lb-a">Clear Bio</button></span>
                     <span class="clear-avatar-link"><button class="clearavatarbtn" class="lb-a">Clear Avatar</button></span>
                     <span class="delete-account-link"><button class="deletebtn">Delete account</button></span>

--- a/Views/new-account.phtml
+++ b/Views/new-account.phtml
@@ -2,16 +2,23 @@
 <div class="txt-c display-block">
     <form method="post" class="newaccform">
         <div class="pw-box">
-        <label for="name" class="mb-l lb-a">Display name</label>
-        <input class="login-form" type="text" name="name" id="name" class="mb-d"/>
+            <label for="name" class="mb-l lb-a">Display name</label>
+            <input class="login-form" type="text" name="name" id="name" class="mb-d"/>
         </div>
         <div class="pw-box">
-        <label for="discord" class="mb-l lb-b lb-a">Discord handle</label>
-        <input class="login-form" type="text" name="discord" id="discord" class="mb-d"/>
+            <label for="discord" class="mb-l lb-b lb-a">Discord handle</label>
+            <input class="login-form" type="text" name="discord" id="discord" class="mb-d"/>
         </div>
         <div class="pw-box">
-        <label for="password" class="mb-l lb-b lb-a">Password</label>
-        <input class="login-form" type="text" name="password" id="password" class="mb-d lb-a" value="<?= ${str_replace('-', '', basename(__FILE__, '.phtml')).'_password'}; ?>" placeholder="Will be generated" readonly/>
+            <label for="ccc" class="mb-l lb-b lb-a">CCC username</label>
+            <input class="login-form" type="text" name="ccc" id="ccc" class="mb-d"/>
+        </div>
+        <div class="pw-box">
+            <label for="password" class="mb-l lb-b lb-a">Password</label>
+            <input class="login-form" type="text" name="password" id="password" class="mb-d lb-a" value="<?= ${str_replace('-', '', basename(__FILE__, '.phtml')).'_password'}; ?>" placeholder="Will be generated" readonly/>
+        </div>
+        <div class="pw-box" <?php if (empty(${str_replace('-', '', basename(__FILE__, '.phtml')).'_userId'})) : ?>style="display:none"<?php endif ?>>
+            <a href="/account/<?= ${str_replace('-', '', basename(__FILE__, '.phtml')).'_userId'}; ?>">Edit the account info</a>
         </div>
         <p class="lb-b mb-s mt-s"><input class="login-form submit" type="submit" value="Create" /></p>
     </form>

--- a/css/accounts.css
+++ b/css/accounts.css
@@ -18,7 +18,7 @@ table {
     margin: 0!important;
 }
 
-.buttons-column>span>button{
+.buttons-column>span>button, .buttons-column>a>button{
     font-size: 13px;
     border-radius: 0;
     min-width: 125px;

--- a/css/administration.css
+++ b/css/administration.css
@@ -58,6 +58,10 @@ td th {
     padding: 10px 5px;
 }
 
+.resetpasswordbtn { background: rgb(54, 150, 243);}
+.resetpasswordbtn:hover { background: rgb(57, 151, 185);}
+.manageaccbtn { background: rgb(243, 54, 120);}
+.manageaccbtn:hover { background: rgb(185, 57, 149);}
 .clearbiobtn { background: rgb(247, 225, 32);}
 .clearbiobtn:hover { border-color: rgb(211, 195, 50);}
 .clearavatarbtn { background: rgb(255, 127, 0);}

--- a/routes.ini
+++ b/routes.ini
@@ -50,5 +50,6 @@
 /api/unvoiced-line-report/reset=Api\LineReporting\LineReporter?resetForwarded
 /api/unvoiced-line-report/accepted=Api\LineReporting\LineReporter?getAcceptedReports
 /api/unvoiced-line-report/active=Api\LineReporting\LineReporter?getActiveReports
+/api/unvoiced-line-report/valid=Api\LineReporting\LineReporter?getValidReports
 
 /api/content/quest-info=Api\Other\Content?quests

--- a/routes.ini
+++ b/routes.ini
@@ -20,7 +20,8 @@
 /download/<0>/exe=Website\Download?get?<0>?installer
 /faq=Website\Faq
 /login=Website\Account\Login
-/account=Website\Account\Account
+/account=Website\Account\Account?self
+/account/<0>=Website\Account\Account?<0>
 /administration=Website\Administration\Administration?accounts
 /administration/accounts=Website\Administration\Administration?accounts
 /administration/accounts/<0>/reset-password=Website\Administration\Administration?accounts?reset-password?<0>


### PR DESCRIPTION
- New API route is defined – it can be used to get a list of all reports for a given NPC, excluding only the rejected ones. It can also be used to get all non-rejected reports (by not specifying the NPC).
- Users' accounts can now be edited by system administrators. This feature is meant to be used **only** to initialize the account upon creating it if the future owner of it isn't going to fill in the account information and is okay if the details are copied e.g. from their CCC portfolio.
- When creating a new user account, the Discord handle is no longer required to be specified and the CCC account can be linked immediately.