### PR TITLE
Installer not found error fix and version update

### DIFF
--- a/Models/Website/DownloadsManager.php
+++ b/Models/Website/DownloadsManager.php
@@ -10,7 +10,7 @@ class DownloadsManager
     public const DOWNLOAD_TYPE_INSTALLER = 'exe';
     
     public const ROOT_DOWNLOADS_DIRECTORY = 'files/mod';
-    public const INSTALLER_FILE_NAME = 'VoicesOfWynn-Installer-v1.0.exe'; //Both on the server and when downloaded
+    public const INSTALLER_FILE_NAME = 'VoicesOfWynn-Installer-v1.1.jar'; //Both on the server and when downloaded
     private const FILE_NAME_FORMATS = 'VoicesOfWynn-MC{mcVersion}-v{version}.jar';
 
     /**

--- a/Views/download-details.phtml
+++ b/Views/download-details.phtml
@@ -69,7 +69,7 @@ It doesn\'t contain much new content';
             <td><strong>Recommended for updating and people with unstable internet connection.</strong></td>
         </tr><tr>
             <td><?= round($downloadDetails->size / 1000000, 2) ?> MB <code>.jar</code> file</td>
-            <td><?= round(${str_replace('-', '', basename(__FILE__, '.phtml')).'_installerSize'} / 1000, 2) ?> kB <code>.exe</code> file</td>
+            <td><?= round(${str_replace('-', '', basename(__FILE__, '.phtml')).'_installerSize'} / 1000, 2) ?> kB executable <code>.jar</code> file</td>
         </tr><tr>
             <td>Download must be restarted from the beginning in case of a failure.</td>
             <td>In case of a failure, the installation can be resumed.</td>


### PR DESCRIPTION
`DownloadsManager.php` was serving a non-existent file (so an empty exe) because the filename constant was incorrect.

Also, the new installer version (1.1) will now be served.