### PR TITLE
Fixed ordering of releases released the same day

### DIFF
--- a/Models/Website/DownloadsManager.php
+++ b/Models/Website/DownloadsManager.php
@@ -21,7 +21,7 @@ class DownloadsManager
     public function listDownloads(): array
     {
         $db = new Db('Website/DbInfo.ini');
-        $result = $db->fetchQuery('SELECT * FROM download ORDER BY release_date DESC', array(), true);
+        $result = $db->fetchQuery('SELECT * FROM download ORDER BY release_date DESC, version DESC, mc_version DESC', array(), true);
 
         if ($result === false) {
             return array();


### PR DESCRIPTION
They used to be ordered by ID (so from the oldest update released on that day). Now, in case two releases have the same date of release, they'll be compared in their version and mc_versions fields. This will make sure that the newest mod version for the newest MC version will always be at the top.