### PR TITLE
Fix of credits and administration pages returning 500 HTTP error after introduction of the user.discord_id column

### DIFF
--- a/Controllers/Website/WebpageController.php
+++ b/Controllers/Website/WebpageController.php
@@ -122,7 +122,7 @@ abstract class WebpageController extends Controller
                     $discordId = $this->sanitize($value->getDiscordId());
                     $email = $this->sanitize($value->getEmail());
                     $name = $this->sanitize($value->getName());
-                    $avatarLink = $this->sanitize($value->getAvatarLink(false));
+                    $avatarLink = $this->sanitize($value->getAvatar());
                     $bio = $value->getBio(); //Don't sanitize, dangerous tags are removed before saving to the database
                     $lore = $this->sanitize($value->getLore());
                     $roles = $this->sanitize($value->getRoles());

--- a/Models/Website/User.php
+++ b/Models/Website/User.php
@@ -19,7 +19,7 @@ class User implements JsonSerializable
     private bool $loaded = false;
 
     private int $id = 0;
-    private $discordId = '';
+    private $discordId = null;
     private $email = '';
     private string $hash = '';
     private bool $systemAdmin = false;
@@ -305,9 +305,9 @@ class User implements JsonSerializable
 
     /**
      * Summary of getDiscordId
-     * @return int
+     * @return ?int Discord ID of this user of NULL if it hasn't been specified yet
      */
-    public function getDiscordId():int
+    public function getDiscordId():?int
     {
         return $this->discordId;
     }

--- a/Models/Website/User.php
+++ b/Models/Website/User.php
@@ -337,6 +337,19 @@ class User implements JsonSerializable
     }
     
     /**
+     * Method returning filename of the avatar image without any additional path to it
+     * This should only ever be used by anti-XSS sanitizer to not duplicate the path part of the full filename
+     * @return string Filename of the avatar of this user
+     */
+    public function getAvatar(): string
+    {
+        if (!$this->loaded && empty($this->avatarLink)) {
+            $this->load();
+        }
+        return $this->avatarLink;
+    }
+	
+    /**
      * Method returning link of avatar image that should be displayed.
      * By defualt, the avatar set manually by the user in their account settings is used. If none has been set, the one
      * fetched from Discord (downloaded during account creation via API) is returned (if such avatar exists).

--- a/Views/account.phtml
+++ b/Views/account.phtml
@@ -83,7 +83,7 @@
                 <label for="avatar">Picture</label>
             </div>
             <div class="account-edit-field-right input-change" id='account-edit-field-img'>
-                <img id="avatar-preview" src="dynamic/avatars/<?= ${basename(__FILE__, '.phtml').'_picture'} ?>"
+                <img id="avatar-preview" src="<?= ${basename(__FILE__, '.phtml').'_picture'} ?>"
                     alt="Your Profile Picture" />
                 <input id="avatar-input" class="input-change" name="avatar" type="file" accept="image/png,image/jpeg" />
             </div>


### PR DESCRIPTION
The `discord_id` column is now set to `BIGINT` in the database and the default value in the `User` model that was causing the 500 error is now set to `null` (was `''`).

Also, a hard-to-find bug that was causing the relative path to all avatar images to be duplicated (for example `/dynamic/avatars/dynamic/avatars/2.png`) was fixed (our anti-XSS sanitiser was the culprit).

Fix has already been deployed (or more accurately, I was fixing it on production again...)