### PR TITLE
Turn of displaying errors and fix a PHP compatibility issue

### DIFF
--- a/Models/Api/LineReporting/Report.php
+++ b/Models/Api/LineReporting/Report.php
@@ -58,7 +58,7 @@ class Report implements JsonSerializable
         }
     }
 
-    public function jsonSerialize(): array
+    public function jsonSerialize() : mixed
     {
         $properties = array();
 

--- a/Models/Website/Npc.php
+++ b/Models/Website/Npc.php
@@ -49,7 +49,7 @@ class Npc implements JsonSerializable
 		}
 	}
 
-	public function jsonSerialize() : object
+	public function jsonSerialize() : mixed
 	{
 	    return (object) get_object_vars($this);
 	}

--- a/Models/Website/Quest.php
+++ b/Models/Website/Quest.php
@@ -36,7 +36,7 @@ class Quest implements JsonSerializable
 		}
 	}
 	
-	public function jsonSerialize()
+	public function jsonSerialize() : mixed
 	{
 	    return (object) get_object_vars($this);
 	}

--- a/Models/Website/User.php
+++ b/Models/Website/User.php
@@ -35,7 +35,7 @@ class User implements JsonSerializable
     
     private array $roles = array();
 
-    public function jsonSerialize()
+    public function jsonSerialize() : mixed
 	{
 	    return (object) [
             'id' => $this->id,

--- a/php.ini
+++ b/php.ini
@@ -1,1 +1,2 @@
 session.save_path = "/var/www/html/sessions"
+display_errors = Off


### PR DESCRIPTION
- Errors are no longer being echoed directly to users (security issue)
- Dealt with deprecation notice from inconsistent return values for JsonSerializable::jsonSerialize().