### PR TITLE
Whitelist video/ogg in recording uploader

### DIFF
--- a/Models/Website/RecordingUploader.php
+++ b/Models/Website/RecordingUploader.php
@@ -45,11 +45,11 @@ class RecordingUploader
                 continue;
             }
 
-            if ($type !== 'audio/ogg') {
+            if ($type !== 'audio/ogg' && $type !== 'video/ogg') { //Our server is treating audio/ogg as video/ogg for some reason
                 $this->errors[] = [
                     'code' => 415,
                     'msg' => 'Unsupported Media Type',
-                    'desc' => 'The uploaded file is not in the correct format, only OGG files are allowed',
+                    'desc' => 'The uploaded file is not in the correct format, only OGG files are allowed, MIME-type '.$type.' provided',
                     'file' => $filename
                 ];
                 continue;


### PR DESCRIPTION
Our server is treating OGG audio files as if they had video/ogg MIME-type for some reason.

This pull request whitelists the video MIME-type as well, as a lazy fix (should be safe though, since only system administrators have access to that uploader utility).